### PR TITLE
Allow installing new tarsnap binary over old version

### DIFF
--- a/tasks/tarsnap.yml
+++ b/tasks/tarsnap.yml
@@ -63,7 +63,7 @@
 
 - name: Build and install Tarsnap
   when: tarnsap_installed|failed
-  command: make all install clean chdir=/root/tarsnap-autoconf-{{ tarsnap_version }} creates=/usr/local/bin/tarsnap
+  command: make all install clean chdir=/root/tarsnap-autoconf-{{ tarsnap_version }}
 
 - name: Create Tarsnap cache directory
   file: state=directory path={{ tarsnap_cache }}


### PR DESCRIPTION
This PR removes the `creates=` which prevents the task from running when `/usr/bin/tarsnap` exists.
All of these tasks [will be skipped](https://github.com/open-craft/ansible-tarsnap/blob/07ffa9d755747cd617a737ddef5f2296990319f4/tasks/tarsnap.yml#L15) if the correct version of tarsnap is already installed, however when upgrading tarsnap, it won't install because of this `creates=` which prevents the task from running if the file already exists.